### PR TITLE
Add "prepublish" script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You may test your browser [here](http://mapbox.github.io/mapbox-gl-supported).
 ## Using Mapbox GL JS Supported with a `<script>` tag
 
 ```html
-<script src='mapbox-gl-supported.js'></script>
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-supported/v1.1.0/mapbox-gl-supported.js'></script>
 <script>
 if (mapboxgl.supported()) {
     ...

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A library to determine if a browser supports Mapbox GL JS",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js"
+    "test": "eslint index.js",
+    "prepublish": "npm test && npm run publish-s3",
+    "publish-s3": "aws s3 cp --acl public-read index.js s3://mapbox-gl-js/plugins/mapbox-gl-supported/v$(node -p -e \"require('./package.json').version\")/mapbox-gl-supported.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `prepublish` script runs the linter and publishes the library to our CDN on s3.

cc @tristen @karenzshea @jfirebaugh 
