### PR TITLE
remove browserify from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "eslint index.js",
-    "build": "mkdir -p dist && NODE_ENV=production && browserify index.js | uglifyjs -c -m > dist/mapbox-gl-supported.js"
+    "build": "mkdir -p dist && uglifyjs index.js -c -m -o dist/mapbox-gl-supported.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The browserify step in the build script was adding some unnecessary code to `mapbox-gl-supported.js` and causing some errors down the line. This PR removes the browserify step. 

cc @tristen 
