### PR TITLE
minor version bump for build script changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-supported",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A library to determine if a browser supports Mapbox GL JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumping version number to account for build script changes in https://github.com/mapbox/mapbox-gl-supported/pull/8
