### PR TITLE
Work around Blob bug in Safari 5.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function isJSONSupported() {
 }
 
 function isWorkerSupported() {
-    if (!('Worker' in window && 'Blob' in window)) {
+    if (!('Worker' in window && 'Blob' in window && 'URL' in window)) {
         return false;
     }
 


### PR DESCRIPTION
While testing our new website in Safari 5.1 using BrowserStack I came across an obscure bug in Safari's handling of Blob.

It results in `isWorkerSupported()` generating a TypeError exception:
```
TypeError: '[object BlobConstructor]' is not a constructor (evaluating 'new Blob([''], { type: 'text/javascript' })')
```
![macsl_safari_5 1](https://user-images.githubusercontent.com/1215089/37702596-287f7a52-2d47-11e8-9db9-dcf9f626f0e5.jpg)

If this exception is caught and handled then the script loads properly and returns not supported.

