### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-gl-supported#readme",
   "devDependencies": {
-    "browserify": "^11.2.0",
+    "browserify": "^16.2.3",
     "eslint": "^2.8.0",
     "eslint-config-mourner": "^2.0.1",
     "uglify-js": "^2.4.24"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "eslint": "^2.8.0",
     "eslint-config-mourner": "^2.0.1",
     "uglify-js": "^2.4.24"
+  },
+  "peerDependencies": {
+    "mapbox-gl": ">=0.32.1 <2.0.0"
   }
 }


### PR DESCRIPTION
- Add `mapbox-gl` as a peer dependency so npm will ensure the correct version of GL JS is installed alongside the plugin
- Update other dependencies to fix `npm audit` vulnerabilities