### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-supported",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A library to determine if a browser supports Mapbox GL JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Create a new release to include `peerDependency` update from #23 
cc @mapbox/gl-js 