### PR TITLE
Make all const variables var

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,13 +118,13 @@ function isArrayBufferSupported() {
 // Some browsers or browser extensions block access to canvas data to prevent fingerprinting.
 // Mapbox GL uses this API to load sprites and images in general.
 function isCanvasGetImageDataSupported() {
-    const canvas = document.createElement('canvas');
+    var canvas = document.createElement('canvas');
     canvas.width = canvas.height = 1;
-    const context = canvas.getContext('2d');
+    var context = canvas.getContext('2d');
     if (!context) {
         return false;
     }
-    const imageData = context.getImageData(0, 0, 1, 1);
+    var imageData = context.getImageData(0, 0, 1, 1);
     return imageData && imageData.width === canvas.width;
 }
 
@@ -158,14 +158,14 @@ function getWebGLContext(failIfMajorPerformanceCaveat) {
 }
 
 function isWebGLSupported(failIfMajorPerformanceCaveat) {
-    const gl = getWebGLContext(failIfMajorPerformanceCaveat);
+    var gl = getWebGLContext(failIfMajorPerformanceCaveat);
     if (!gl) {
         return false;
     }
 
     // Try compiling a shader and get its compile status. Some browsers like Brave block this API
     // to prevent fingerprinting. Unfortunately, this also means that Mapbox GL won't work.
-    const shader = gl.createShader(gl.VERTEX_SHADER);
+    var shader = gl.createShader(gl.VERTEX_SHADER);
     if (!shader || gl.isContextLost()) {
         return false;
     }


### PR DESCRIPTION
This makes it so that the consumer doesn't have to care about ES6 support when using this library as standalone. In my case that is UglifyJS in my build pipeline which does not support ES6. I could probably make it so that I transpile before minifying the code, but there could be other people who may run into this issue as well. And also, using `var` seem to match the library style better anyhow.

An alternative would be to make a more elaborate build pipeline for this library to supply a dist library, which seem to have been the case previously, but was removed.